### PR TITLE
Speedup for `did2s()`

### DIFF
--- a/R/did2s.R
+++ b/R/did2s.R
@@ -338,14 +338,14 @@ did2s_estimate <- function(data, yname, first_stage, second_stage, treatment,
 # Subset sparse matrices
 # This is needed when subset has 1 column or 1 row
 make_g <- function(x, in_cl, n_row) {
-  ncol <- dim(x)[[2]]
+  n_col <- dim(x)[[2]]
 
   if (inherits(x, "dgCMatrix")) {
-    if (n_row == 1 | ncol == 1) {
+    if (n_row == 1 | n_col == 1) {
       return(
         Matrix::Matrix(x[in_cl, ],
           sparse = T,
-          nrow = n_row, ncol = ncol
+          nrow = n_row, ncol = n_col
         )
       )
     } else {

--- a/R/did2s.R
+++ b/R/did2s.R
@@ -153,7 +153,7 @@ did2s <- function(data, yname, first_stage, second_stage, treatment, cluster_var
     } else {
       weights_vector <- sqrt(data[[weights]])
     }
-    
+
     # Extract first stage
     first_u <- est$first_u
     if (!is.null(removed_rows)) first_u <- first_u[removed_rows]
@@ -183,7 +183,7 @@ did2s <- function(data, yname, first_stage, second_stage, treatment, cluster_var
     # Note: SparseM relies on A (x10'x10) being positive symmetric for solving
     V <- MatrixExtra::t_deep(
       SparseM::solve(
-        Matrix::crossprod(x10), 
+        Matrix::crossprod(x10),
         MatrixExtra::t_shallow(Matrix::crossprod(x2, x1))
       )
     )
@@ -195,17 +195,19 @@ did2s <- function(data, yname, first_stage, second_stage, treatment, cluster_var
     # W_g = X_2g' e_2g - (X_2' X_12) (X_11' X_11)^-1 X_11g' e_1g
     #     = X_2g' e_2g - V X_11g' e_1g
     meat <- lapply(unique(cl), function(cl_id) {
-      x2_g = make_g(x2, cl, cl_id)
-      x10_g = make_g(x10, cl, cl_id)
-      first_u_g = make_g(first_u, cl, cl_id)
-      second_u_g = make_g(second_u, cl, cl_id)
+      in_cl = (cl == cl_id)
+      n_row = sum(in_cl)
+      x2_g = make_g(x2, in_cl, n_row)
+      x10_g = make_g(x10, in_cl, n_row)
+      first_u_g = make_g(first_u, in_cl, n_row)
+      second_u_g = make_g(second_u, in_cl, n_row)
 
       W = Matrix::crossprod(x2_g, second_u_g) - V %*% Matrix::crossprod(x10_g, first_u_g)
-      
+
       # W' W
       Matrix::tcrossprod(W)
     })
-    
+
     meat_sum <- Reduce("+", meat)
 
     # (X_2'X_2)^-1 (sum W_g W_g') (X_2'X_2)^-1
@@ -335,22 +337,20 @@ did2s_estimate <- function(data, yname, first_stage, second_stage, treatment,
 
 # Subset sparse matrices
 # This is needed when subset has 1 column or 1 row
-make_g <- function(x, cl, cl_id) {
-  in_cl <- (cl == cl_id)
+make_g <- function(x, in_cl, n_row) {
   ncol <- dim(x)[[2]]
-  nrow <- sum(in_cl)
 
   if (inherits(x, "dgCMatrix")) {
-    if (nrow == 1 | ncol == 1) {
+    if (n_row == 1 | ncol == 1) {
       return(
-        Matrix::Matrix(x[cl == cl_id, ],
+        Matrix::Matrix(x[in_cl, ],
           sparse = T,
-          nrow = nrow, ncol = ncol
+          nrow = n_row, ncol = ncol
         )
       )
     } else {
       return(
-        Matrix::Matrix(x[cl == cl_id, ], sparse = T)
+        Matrix::Matrix(x[in_cl, ], sparse = T)
       )
     }
   }


### PR DESCRIPTION
Hello, thanks a lot for this package! I saw your tweet on the large performance improvement you made and I thought maybe there were more to do.

I noticed that some lines in `make_g()` are called several times while once would be enough. Calling these lines only once can lead to a ~1.5x speedup in some cases. Below is a benchmark with a made-up dataset that should be similar to `df_het` (but larger). The function call is the same as in the [README](https://kylebutts.github.io/did2s/articles/Two-Stage-Difference-in-Differences.html#estimate-two-stage-difference-in-differences).

I don't know your preferences regarding the DESCRIPTION and NEWS so either let me know or feel free to commit directly in this branch. 

### Benchmark

#### Setup

``` r
suppressPackageStartupMessages(library(did2s))

foo <- list()
for (i in 1:2500) {
    g <- paste0("Group ", sample(1:3, 1))
    start_rel <- sample(c((-20):(-1), Inf), 1)
    if (is.infinite(start_rel)) {
        rel_year <- rep(Inf, 31)
    } else {
        rel_year <- seq(from = start_rel, by = 1, length.out = 31)
    }
    
    foo[[i]] <- data.frame(
        unit = rep(i, 31),
        state = rep(i+10000, 31),
        group = rep(g, 31),
        rel_year = rel_year,
        dep_var = rnorm(31),
        year = 1990:2020
    ) 
    foo[[i]]$treat <- as.numeric(!is.infinite(foo[[i]]$rel_year) & foo[[i]]$rel_year > 0)
}

dat <- data.table::rbindlist(foo)

head(dat)
#>    unit state   group rel_year    dep_var year treat
#> 1:    1 10001 Group 2      -17 -0.5553937 1990     0
#> 2:    1 10001 Group 2      -16  1.6351042 1991     0
#> 3:    1 10001 Group 2      -15  0.1172385 1992     0
#> 4:    1 10001 Group 2      -14  1.3107047 1993     0
#> 5:    1 10001 Group 2      -13 -2.3333151 1994     0
#> 6:    1 10001 Group 2      -12 -0.9034240 1995     0
```

#### Before

``` r
bench::mark(
    did2s = did2s(dat,
          yname = "dep_var", first_stage = ~ 0 | state + year, 
          second_stage = ~i(treat, ref=FALSE), treatment = "treat", 
          cluster_var = "state")
)
#> Running Two-stage Difference-in-Differences
#>  - first stage formula `~ 0 | state + year`
#>  - second stage formula `~ i(treat, ref = FALSE)`
#>  - The indicator variable that denotes when treatment is on is `treat`
#>  - Standard errors will be clustered by `state`
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 did2s         13.3s    13.3s    0.0754    7.71GB     9.20
```

#### After

``` r
bench::mark(
    did2s = did2s(dat,
          yname = "dep_var", first_stage = ~ 0 | state + year, 
          second_stage = ~i(treat, ref=FALSE), treatment = "treat", 
          cluster_var = "state")
)
#> Running Two-stage Difference-in-Differences
#>  - first stage formula `~ 0 | state + year`
#>  - second stage formula `~ i(treat, ref = FALSE)`
#>  - The indicator variable that denotes when treatment is on is `treat`
#>  - Standard errors will be clustered by `state`
#> 
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 did2s         8.72s    8.72s     0.115     4.1GB     7.57
```

---

As a sidenote, I'm not super familiar with the package or with the code inside so it's nice to have tests to be sure I didn't mess up anything. I think it would be even better to have some checks on numerical results (even just the first coefficient) to avoid changes that don't error but modify the results.


